### PR TITLE
v0.4.1

### DIFF
--- a/lib/twirp/rails.rb
+++ b/lib/twirp/rails.rb
@@ -6,6 +6,7 @@ require "twirp/rails/configurations/logging"
 require "twirp/rails/configuration"
 require 'twirp/rails/logging/adapter'
 require 'twirp/rails/logging/subscriber'
+require "twirp/rails/service_wrapper"
 require "twirp/rails/helpers/hooks"
 require "twirp/rails/helpers/services"
 require "twirp/rails/routes"

--- a/lib/twirp/rails/helpers/services.rb
+++ b/lib/twirp/rails/helpers/services.rb
@@ -36,7 +36,7 @@ module Twirp
               )
             end
 
-            service = service_klass.new(new)
+            service_wrapper = Twirp::Rails::ServiceWrapper.new(service_klass.new(new))
 
             hooks = base_hooks + hooks
 
@@ -45,10 +45,10 @@ module Twirp
               if hook_klass.nil?
                 raise ArgumentError.new("Unknown hook #{hook} for #{namespace} namespace")
               end
-              hook_klass.attach(service)
+              hook_klass.attach(service_wrapper.service)
             end
 
-            Twirp::Rails.services << [service, namespace, context]
+            Twirp::Rails.services << [service_wrapper, namespace, context]
           end
         end
       end

--- a/lib/twirp/rails/service_wrapper.rb
+++ b/lib/twirp/rails/service_wrapper.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Twirp
+  module Rails
+    class ServiceWrapper
+      attr_reader :service
+
+      def initialize(service)
+        @service = service
+        @before_route_request = []
+        @on_error = []
+        @exception_raised = []
+      end
+
+      def before_route_request(&block) @before_route_request << block; end
+
+      def on_error(&block)
+        service.on_error(&block)
+        @on_error << block
+      end
+
+      def exception_raised(&block)
+        service.exception_raised(&block)
+        @exception_raised << block
+      end
+
+      def call(rack_env)
+        rack_request = Rack::Request.new(rack_env)
+
+        content_type = rack_request.get_header("CONTENT_TYPE")
+        path_parts = rack_request.fullpath.split("/")
+        method_name = path_parts[-1]
+        base_env = service.class.rpcs[method_name] || {}
+
+        env = base_env.merge(
+          content_type: content_type
+        )
+
+        @before_route_request.each do |hook|
+          result = hook.call(rack_env, env)
+          return error_response(result, env) if result.is_a? ::Twirp::Error
+        end
+
+        service.call(rack_env)
+      end
+
+      def method_missing(method, *args, &block)
+        if service.respond_to?(method)
+          service.send(method, *args, &block)
+        else
+          super
+        end
+      end
+
+      private
+
+      def error_response(twerr, env)
+        begin
+          @on_error.each{|hook| hook.call(twerr, env) }
+          service.class.error_response(twerr)
+        rescue => e
+          return exception_response(e, env)
+        end
+      end
+
+      def exception_response(e, env)
+        raise e if service.class.raise_exceptions
+
+        begin
+          @exception_raised.each{|hook| hook.call(e, env) }
+        rescue => hook_e
+          e = hook_e
+        end
+
+        twerr = Twirp::Error.internal_with(e)
+        service.class.error_response(twerr)
+      end
+    end
+  end
+end

--- a/lib/twirp/rails/version.rb
+++ b/lib/twirp/rails/version.rb
@@ -1,5 +1,5 @@
 module Twirp
   module Rails
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end

--- a/twirp-rails.gemspec
+++ b/twirp-rails.gemspec
@@ -23,8 +23,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency "railties", ">= 4.2"
   spec.add_dependency 'twirp'
+
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
* Fixes an issue where logging would raise an error if the request failed too early in Twirp before the `before` hook could be called. This resulted in an `ActiveSupport::Notification` event not being started, but still attempting to send a `finish` event during the `on_error` hook.